### PR TITLE
Warning with notice on fresh install

### DIFF
--- a/component/components/com_foo/views/foo/tmpl/default.php
+++ b/component/components/com_foo/views/foo/tmpl/default.php
@@ -17,6 +17,6 @@ HTMLHelper::_('script', 'com_foo/script.js', array('version' => 'auto', 'relativ
 HTMLHelper::_('stylesheet', 'com_foo/style.css', array('version' => 'auto', 'relative' => true));
 
 $layout = new FileLayout('foo.page');
-$data = new stdClass;
-$data->text = 'Hello Joomla!';
+$data = array();
+$data['text'] = 'Hello Joomla!';
 echo $layout->render($data);


### PR DESCRIPTION
Did a fresh install with PHPStorm. Got PHP warning and notice:

> Warning: extract() expects parameter 1 to be array, object given in .../components/com_mycomponent/layouts/anysell/page.php on line 13
> 
> Notice: Undefined variable: text in .../components/com_mycomponent/layouts/anysell/page.php on line 15
> 

**Also one question**: Is there any official documentation on J4.x component development with namespaces, layouts etc?