### PR TITLE
Component - use namespaces for sidebar, submenu, and toolbar

### DIFF
--- a/component/administrator/components/com_foo/helpers/foo.php
+++ b/component/administrator/components/com_foo/helpers/foo.php
@@ -32,6 +32,6 @@ class FooHelper
 	 */
 	public function addSubmenu($vName)
 	{
-		HTMLHelper::_('sidebar.addEntry', Text::_('COM_FOO'), 'index.php?option=com_foo&view=foo', $submenu == 'foo');
+		HTMLHelper::_('sidebar.addEntry', Text::_('COM_FOO'), 'index.php?option=com_foo&view=foo', $vName == 'foo');
 	}
 }

--- a/component/administrator/components/com_foo/helpers/foo.php
+++ b/component/administrator/components/com_foo/helpers/foo.php
@@ -32,6 +32,6 @@ class FooHelper
 	 */
 	public function addSubmenu($vName)
 	{
-		HTML::_('sidebar.addEntry', Text::_('COM_FOO'), 'index.php?option=com_foo&view=foo', $submenu == 'foo');
+		HTMLHelper::_('sidebar.addEntry', Text::_('COM_FOO'), 'index.php?option=com_foo&view=foo', $submenu == 'foo');
 	}
 }

--- a/component/administrator/components/com_foo/helpers/foo.php
+++ b/component/administrator/components/com_foo/helpers/foo.php
@@ -9,6 +9,7 @@
  */
 
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\HTML\HTMLHelper;
 
 defined('_JEXEC') or die;
 
@@ -31,6 +32,6 @@ class FooHelper
 	 */
 	public function addSubmenu($vName)
 	{
-		JHtmlSidebar::addEntry(Text::_('COM_FOO'), 'index.php?option=com_foo&view=foo', $vName == 'foo');
+		HTML::_('sidebar.addEntry', Text::_('COM_FOO'), 'index.php?option=com_foo&view=foo', $submenu == 'foo');
 	}
 }

--- a/component/administrator/components/com_foo/views/foo/view.html.php
+++ b/component/administrator/components/com_foo/views/foo/view.html.php
@@ -11,6 +11,8 @@
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView;
+use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Toolbar\ToolbarHelper;
 
 defined('_JEXEC') or die;
 
@@ -56,7 +58,7 @@ class FooViewFoo extends HtmlView
 		// Show the sidebar
 		$this->helper = new FooHelper;
 		$this->helper->addSubmenu('foo');
-		$this->sidebar = JHtmlSidebar::render();
+		$this->sidebar = HTMLHelper::_('sidebar.render');
 
 		// Display it all
 		return parent::display($tpl);
@@ -71,12 +73,12 @@ class FooViewFoo extends HtmlView
 	 */
 	private function toolbar()
 	{
-		JToolBarHelper::title(Text::_('COM_FOO'), '');
+		ToolBarHelper::title(Text::_('COM_FOO'), '');
 
 		// Options button.
 		if (Factory::getUser()->authorise('core.admin', 'com_foo'))
 		{
-			JToolBarHelper::preferences('com_foo');
+			ToolBarHelper::preferences('com_foo');
 		}
 	}
 }


### PR DESCRIPTION
This PR uses swaps the sidebar, submenu and toolbar to utilize namespaces.

These are things I find myself swapping each time when using this boilerplate.