### PR TITLE
remove version attribute

### DIFF
--- a/plugin/system/foo.xml
+++ b/plugin/system/foo.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<extension type="plugin" version="3.8" group="system" method="upgrade">
+<extension type="plugin" group="system" method="upgrade">
 	<name>PLG_FOO</name>
 	<creationDate>[DATE]</creationDate>
 	<author>[AUTHOR]</author>


### PR DESCRIPTION
according to https://docs.joomla.org/Manifest_files, the version attribute is not used in Joomla 3.x and has been removed from Joomla 4.0 and higher.